### PR TITLE
feat: add authentication to import endpoint

### DIFF
--- a/authorization-service/.gitignore
+++ b/authorization-service/.gitignore
@@ -1,0 +1,7 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+.env

--- a/authorization-service/README.md
+++ b/authorization-service/README.md
@@ -1,0 +1,58 @@
+# Serverless Framework AWS NodeJS Example
+
+This template demonstrates how to deploy a NodeJS function running on AWS Lambda using the traditional Serverless Framework. The deployed function does not include any event definitions as well as any kind of persistence (database). For more advanced configurations check out the [examples repo](https://github.com/serverless/examples/) which includes integrations with SQS, DynamoDB or examples of functions that are triggered in `cron`-like manner. For details about configuration of specific `events`, please refer to our [documentation](https://www.serverless.com/framework/docs/providers/aws/events/).
+
+## Usage
+
+### Deployment
+
+In order to deploy the example, you need to run the following command:
+
+```
+$ serverless deploy
+```
+
+After running deploy, you should see output similar to:
+
+```bash
+Deploying aws-node-project to stage dev (us-east-1)
+
+✔ Service deployed to stack aws-node-project-dev (112s)
+
+functions:
+  hello: aws-node-project-dev-hello (1.5 kB)
+```
+
+### Invocation
+
+After successful deployment, you can invoke the deployed function by using the following command:
+
+```bash
+serverless invoke --function hello
+```
+
+Which should result in response similar to the following:
+
+```json
+{
+    "statusCode": 200,
+    "body": "{\n  \"message\": \"Go Serverless v3.0! Your function executed successfully!\",\n  \"input\": {}\n}"
+}
+```
+
+### Local development
+
+You can invoke your function locally by using the following command:
+
+```bash
+serverless invoke local --function hello
+```
+
+Which should result in response similar to the following:
+
+```
+{
+    "statusCode": 200,
+    "body": "{\n  \"message\": \"Go Serverless v3.0! Your function executed successfully!\",\n  \"input\": \"\"\n}"
+}
+```

--- a/authorization-service/handlers/basicAuthorizer.js
+++ b/authorization-service/handlers/basicAuthorizer.js
@@ -1,0 +1,46 @@
+module.exports.handler = async (event) => {
+  const { headers, methodArn } = event;
+  const principalId = 'test';
+
+  if (!headers.Authorization) {
+    throw new Error('Unauthorized');
+  }
+
+  const [authType, encodedToken] = headers.Authorization.split(': ');
+  console.log('auth type: ', authType);
+  console.log('encoded token: ', encodedToken);
+
+  const decodedToken = Buffer.from(encodedToken, 'base64').toString('binary');
+  console.log('decoded token: ', decodedToken);
+
+  const userToken = `${process.env.GITHUB_USERNAME}:${process.env.USER_PASSWORD}`;
+  console.log('user token: ', userToken);
+
+  console.log('envs: ', JSON.stringify(process.env));
+
+  const policyDocument = decodedToken === userToken ? {
+    'Version': '2012-10-17',
+    'Statement': [
+      {
+        'Action': 'execute-api:Invoke',
+        'Effect': 'Allow',
+        'Resource': methodArn,
+      }
+    ]
+  } : {
+    'Version': '2012-10-17',
+    'Statement': [
+      {
+        'Action': 'execute-api:Invoke',
+        'Effect': 'Deny',
+        'Resource': methodArn,
+      }
+    ]
+  }
+  console.log('PolicyDocument: ', JSON.stringify(policyDocument));
+
+  const response = { policyDocument, principalId };
+  console.log('Response: ', JSON.stringify(response));
+
+  return response;
+};

--- a/authorization-service/serverless.yml
+++ b/authorization-service/serverless.yml
@@ -1,0 +1,16 @@
+service: authorization-service
+frameworkVersion: '3'
+
+useDotenv: true
+
+provider:
+  name: aws
+  runtime: nodejs18.x
+  profile: sandx
+  environment:
+    GITHUB_USERNAME: ${env:GITHUB_USERNAME}
+    USER_PASSWORD: ${env:USER_PASSWORD}
+
+functions:
+  basicAuthorizer:
+    handler: handlers/basicAuthorizer.handler

--- a/import-service/serverless.yml
+++ b/import-service/serverless.yml
@@ -6,6 +6,18 @@ custom:
   FOLDER_TO_UPLOAD: uploaded
   CATALOG_ITEMS_QUEUE_URL: https://sqs.us-east-1.amazonaws.com/012536406137/product-service-catalog-items-queue
 
+resources:
+  Resources:
+    Unauthorized:
+      Type: AWS::ApiGateway::GatewayResponse
+      Properties:
+        ResponseParameters:
+          "gatewayresponse.header.Access-Control-Allow-Origin": "'*'"
+          "gatewayresponse.header.Access-Control-Allow-Headers": "'*'"
+        ResponseType: "DEFAULT_4XX"
+        RestApiId:
+          Ref: "ApiGatewayRestApi"
+
 provider:
   name: aws
   runtime: nodejs18.x
@@ -38,6 +50,11 @@ functions:
             parameters:
               querystrings:
                 name: true
+          cors: true
+          authorizer:
+            type: request
+            arn: arn:aws:lambda:us-east-1:012536406137:function:authorization-service-dev-basicAuthorizer
+            resultTtlInSeconds: 0
   importFileParser:
     handler: handlers/importFileParser.handler
     events:


### PR DESCRIPTION
## 70 points
- [x] authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
- [x] Import Service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
- [x] Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser [localStorage](https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage)
## Additional points
- [x] +30 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file.

### Links:
[FE Repository](https://github.com/kalinatimka/shop-angular-cloudfront/pull/4)
[Site](https://d1ljtz4c5accc1.cloudfront.net/)